### PR TITLE
Makes Hit immutable

### DIFF
--- a/src/main/java/nl/inl/blacklab/search/Hit.java
+++ b/src/main/java/nl/inl/blacklab/search/Hit.java
@@ -29,7 +29,7 @@ import nl.inl.blacklab.search.lucene.BLSpans;
  * This class has public members for the sake of efficiency; this makes a non-trivial difference
  * when iterating over hundreds of thousands of hits.
  */
-public final class Hit implements Comparable<Hit>, Cloneable {
+public class Hit implements Comparable<Hit>, Cloneable {
 	/**
 	 * Get the hit object from a Spans object.
 	 *

--- a/src/main/java/nl/inl/blacklab/search/Hit.java
+++ b/src/main/java/nl/inl/blacklab/search/Hit.java
@@ -29,7 +29,7 @@ import nl.inl.blacklab.search.lucene.BLSpans;
  * This class has public members for the sake of efficiency; this makes a non-trivial difference
  * when iterating over hundreds of thousands of hits.
  */
-public class Hit implements Comparable<Hit>, Cloneable {
+public final class Hit implements Comparable<Hit>, Cloneable {
 	/**
 	 * Get the hit object from a Spans object.
 	 *
@@ -95,16 +95,16 @@ public class Hit implements Comparable<Hit>, Cloneable {
 	}
 
 	/** The Lucene doc this hits occurs in */
-	public int doc;
+	public final int doc;
 
 	/** End of this hit's span (in word positions).
 	 *
 	 *  Note that this actually points to the first word not in the hit (just like Spans).
 	 */
-	public int end;
+	public final int end;
 
 	/** Start of this hit's span (in word positions) */
-	public int start;
+	public final int start;
 
 //	/** Context information */
 //	public int[] context;

--- a/src/main/java/nl/inl/blacklab/search/Hits.java
+++ b/src/main/java/nl/inl/blacklab/search/Hits.java
@@ -675,14 +675,13 @@ public class Hits implements Iterable<Hit> {
 					maxHitsRetrieved = maxHitsToRetrieve >= 0 && hits.size() >= maxHitsToRetrieve;
 					if (!maxHitsRetrieved) {
 						Hit hit = currentSourceSpans.getHit();
-						//System.out.println("doc: " + h.doc + " + " + currentDocBase + " = " + (h.doc + currentDocBase));
-						hit.doc += currentDocBase;
+						Hit offsetHit = new Hit(hit.doc + currentDocBase, hit.start, hit.end);
 						if (capturedGroups != null) {
 							Span[] groups = new Span[hitQueryContext.numberOfCapturedGroups()];
 							hitQueryContext.getCapturedGroups(groups);
-							capturedGroups.put(hit, groups);
+							capturedGroups.put(offsetHit, groups);
 						}
-						hits.add(hit);
+						hits.add(offsetHit);
 					}
 				}
 			} catch (IOException e) {


### PR DESCRIPTION
Hit being mutated can cause problems in Spans objects (like SpansInBucketsAbstract) that use a HashMap to store Hits.
