### PR TITLE
Saves about 7% of memory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ libraryDependencies ++= Seq(
   "tomcat" % "jasper-runtime" % "5.5.23",
   "tomcat" % "jsp-api" % "5.5.23",
   "tomcat" % "servlet-api" % "5.5.23",
+  "com.goldmansachs" % "gs-collections" % "6.1.0",
   Logging.logbackClassic,
   Logging.logbackCore,
   Logging.slf4jApi,

--- a/src/main/java/nl/inl/blacklab/externalstorage/ContentStoreDirUtf8.java
+++ b/src/main/java/nl/inl/blacklab/externalstorage/ContentStoreDirUtf8.java
@@ -29,11 +29,12 @@ import java.nio.IntBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.gs.collections.api.map.MutableMap;
+import com.gs.collections.impl.factory.Maps;
 import nl.inl.util.ExUtil;
 
 /**
@@ -311,7 +312,7 @@ public class ContentStoreDirUtf8 extends ContentStoreDirAbstract {
 				f.delete();
 			}
 		}
-		toc = new HashMap<Integer, TocEntry>();
+		toc = Maps.mutable.empty();
 		if (tocFile.exists())
 			readToc();
 		tocModified = false;

--- a/src/main/java/nl/inl/blacklab/forwardindex/ForwardIndexImplV3.java
+++ b/src/main/java/nl/inl/blacklab/forwardindex/ForwardIndexImplV3.java
@@ -99,10 +99,10 @@ class ForwardIndexImplV3 extends ForwardIndex {
 	private long writeBufOffset;
 
 	/** The table of contents (where documents start in the tokens file and how long they are) */
-	private List<TocEntry> toc;
+	private ArrayList<TocEntry> toc;
 
 	/** Deleted TOC entries. Always sorted by size. */
-	private List<TocEntry> deletedTocEntries;
+	private ArrayList<TocEntry> deletedTocEntries;
 
 	/** The table of contents (TOC) file, docs.dat */
 	private File tocFile;
@@ -414,6 +414,8 @@ class ForwardIndexImplV3 extends ForwardIndex {
 		} catch (Exception e) {
 			throw ExUtil.wrapRuntimeException(e);
 		}
+		toc.trimToSize();
+		deletedTocEntries.trimToSize();
 	}
 
 	private void sortDeletedTocEntries() {

--- a/src/main/java/nl/inl/blacklab/forwardindex/TermsImplV3.java
+++ b/src/main/java/nl/inl/blacklab/forwardindex/TermsImplV3.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
+import com.gs.collections.impl.factory.Maps;
 import org.apache.log4j.Logger;
 
 /**
@@ -95,9 +96,8 @@ class TermsImplV3 extends Terms {
 			// (used later to get the terms in sort order)
 			this.termIndex = new TreeMap<String, Integer>(this.collator);
 		} else {
-			// Search mode: create a HashMap so insertion is O(1) instead of O(n log n).
 			// We already have the sort order, so TreeMap is not necessary here.
-			this.termIndex = new HashMap<String, Integer>();
+			this.termIndex = Maps.mutable.empty();
 		}
 		termIndexBuilt = true;
 	}


### PR DESCRIPTION
@chrisc36, this just files away at some constants. BlackLab is big enough in memory that 7% is worth it in my mind.

There is more to be had if we used `IntObjectMap` and friends, but that changes the signature of the maps, and is much more invasive.
